### PR TITLE
Added in dashboard.config transform support for nuget & Umbraco packing

### DIFF
--- a/build/Install.ps1
+++ b/build/Install.ps1
@@ -1,0 +1,19 @@
+param($installPath, $toolsPath, $package, $project)
+
+$appPluginsFolder = $project.ProjectItems | Where-Object { $_.Name -eq "App_Plugins" }
+$bulkUserAdminFolder = $appPluginsFolder.ProjectItems | Where-Object { $_.Name -eq "BulkUserAdmin" }
+
+if (!$bulkUserAdminFolder)
+{
+	$newPackageFiles = "$installPath\Content\App_Plugins\BulkUserAdmin"
+
+	$projFile = Get-Item ($project.FullName)
+	$projDirectory = $projFile.DirectoryName
+	$projectPath = Join-Path $projDirectory -ChildPath "App_Plugins"
+	$projectPathExists = Test-Path $projectPath
+
+	if ($projectPathExists) {	
+		Write-Host "Updating Bulk User Admin App_Plugin files using PS as they have been excluded from the project"
+		Copy-Item $newPackageFiles $projectPath -Recurse -Force
+	}
+}

--- a/build/package.proj
+++ b/build/package.proj
@@ -123,6 +123,7 @@
 			<PluginFiles Include="$(CoreProjectDir)\Web\UI\**\*.*" />
 			<PackageFile Include="$(MSBuildProjectDirectory)\package.xml" />
 			<NuSpecFile Include="$(MSBuildProjectDirectory)\package.nuspec" />
+      		<DashboardConfigXDTInstallFile Include="$(MSBuildProjectDirectory)\transforms\dashboard.config.install.xdt" />
 		</ItemGroup>
 		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(BuildUmbDir)\bin" />
 		<Copy SourceFiles="@(PackageFile)" DestinationFolder="$(BuildUmbDir)" />
@@ -132,6 +133,12 @@
 		<Copy SourceFiles="@(PluginFiles)" DestinationFiles="@(PluginFiles->'$(BuildNuGetDir)\Content\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(SrcFiles)" DestinationFiles="@(SrcFiles->'$(BuildNuGetDir)\src\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(NuSpecFile)" DestinationFolder="$(BuildNuGetDir)" />
+
+		<!-- Umbraco -->
+    	<Copy SourceFiles="@(DashboardConfigXDTInstallFile)" DestinationFolder="$(BuildUmbDir)\App_Plugins\BulkUserAdmin\Install" />
+
+		<!-- NuGet -->
+    	<Copy SourceFiles="@(DashboardConfigXDTInstallFile)" DestinationFolder="$(BuildNuGetDir)\Content\Config" />
 	</Target>
 
 	<!-- MANIFEST UMBRACO -->

--- a/build/package.proj
+++ b/build/package.proj
@@ -134,9 +134,6 @@
 		<Copy SourceFiles="@(SrcFiles)" DestinationFiles="@(SrcFiles->'$(BuildNuGetDir)\src\%(RecursiveDir)%(Filename)%(Extension)')" />
 		<Copy SourceFiles="@(NuSpecFile)" DestinationFolder="$(BuildNuGetDir)" />
 
-		<!-- Umbraco -->
-    	<Copy SourceFiles="@(DashboardConfigXDTInstallFile)" DestinationFolder="$(BuildUmbDir)\App_Plugins\BulkUserAdmin\Install" />
-
 		<!-- NuGet -->
     	<Copy SourceFiles="@(DashboardConfigXDTInstallFile)" DestinationFolder="$(BuildNuGetDir)\Content\Config" />
 	</Target>

--- a/build/package.proj
+++ b/build/package.proj
@@ -124,6 +124,8 @@
 			<PackageFile Include="$(MSBuildProjectDirectory)\package.xml" />
 			<NuSpecFile Include="$(MSBuildProjectDirectory)\package.nuspec" />
       		<DashboardConfigXDTInstallFile Include="$(MSBuildProjectDirectory)\transforms\dashboard.config.install.xdt" />
+			  
+ 			<InstallPsFile Include="$(MSBuildProjectDirectory)\Install.ps1" />
 		</ItemGroup>
 		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(BuildUmbDir)\bin" />
 		<Copy SourceFiles="@(PackageFile)" DestinationFolder="$(BuildUmbDir)" />
@@ -136,6 +138,8 @@
 
 		<!-- NuGet -->
     	<Copy SourceFiles="@(DashboardConfigXDTInstallFile)" DestinationFolder="$(BuildNuGetDir)\Content\Config" />
+
+		<Copy SourceFiles="@(InstallPsFile)" DestinationFolder="$(BuildNuGetDir)\tools" />
 	</Target>
 
 	<!-- MANIFEST UMBRACO -->

--- a/build/transforms/dashboard.config.install.xdt
+++ b/build/transforms/dashboard.config.install.xdt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dashBoard xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <section alias="Our.Umbraco.BulkUserAdmin" xdt:Locator="Match(alias)" xdt:Transform="InsertIfMissing">
+    <areas>
+      <area>users</area>
+    </areas>
+    <tab caption="Bulk User Admin">
+      <access>
+        <grant>admin</grant>
+      </access>
+      <control showOnce="false" addPanel="true" panelCaption="">
+        /App_Plugins/BulkUserAdmin/views/bua.dashboard.html
+      </control>
+    </tab>
+  </section>
+</dashBoard>

--- a/src/Our.Umbraco.BulkUserAdmin.sln
+++ b/src/Our.Umbraco.BulkUserAdmin.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Package", "Build Pack
 		..\appveyor.yml = ..\appveyor.yml
 		..\build-appveyor.cmd = ..\build-appveyor.cmd
 		..\build.cmd = ..\build.cmd
+		..\build\install.ps1 = ..\build\install.ps1
 		..\build\package.nuspec = ..\build\package.nuspec
 		..\build\package.proj = ..\build\package.proj
 		..\build\package.xml = ..\build\package.xml


### PR DESCRIPTION
Hey @leekelleher,
As mentioned over [on Twitter](https://twitter.com/jamiepollock/status/747369264164790272) I have added in transformations for config\dashboard.config to add in the dashboard on package install.

I've tested this with nuget & Umbraco local package install on Umbraco v7.5.0 beta. Seems to work well.

Thanks,
Jamie
