### PR TITLE
fix for pagination

### DIFF
--- a/src/Our.Umbraco.BulkUserAdmin/Web/UI/App_Plugins/BulkUserAdmin/js/bua.controllers.js
+++ b/src/Our.Umbraco.BulkUserAdmin/Web/UI/App_Plugins/BulkUserAdmin/js/bua.controllers.js
@@ -30,6 +30,12 @@
         };
 
         $scope.goToPage = function (idx, sortOptions, filter) {
+            if (typeof (sortOptions) === 'undefined')
+                sortOptions = $scope.sortOptions;
+
+            if (typeof (filter) === 'undefined')
+                filter = $scope.filter;
+
             buaResources.getUsers(idx, sortOptions, filter).then(function (data) {
                 $scope.users = data;
 


### PR DESCRIPTION
Pagination links are broken as sort options and filter are undefined.

If you sort on a column and try to browse through the pagination it doesn't work.